### PR TITLE
Upgrade to Ubuntu Xenial

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Vagrant box for front-end development
 This is a simple vagrant box I use for front-end development. It come with:
 
-  * Ubuntu 14.04 x64.
+  * Ubuntu 16.04 x64.
   * The latest version of Git.
   * Node.js 4.x LTS version.
   * The latest version of npm.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,7 +13,7 @@ Vagrant.configure("2") do |config|
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
   #config.vm.box = "base"
-  config.vm.box = "ubuntu/trusty64"
+  config.vm.box = "ubuntu/xenial64"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs


### PR DESCRIPTION
As Ubuntu Trusty is approaching EoL in April 2019, this updates the box to Ubuntu Xenial 16.04 LTS, extending the support util April 2021.

