### PR TITLE
Upgrade Node to 10.x LTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This is a simple vagrant box I use for front-end development. It come with:
 
   * Ubuntu 16.04 x64.
   * The latest version of Git.
-  * Node.js 6.x LTS version.
+  * Node.js 10.x LTS version.
   * The latest version of npm.
   * The latest version of Gulp (gulp-cli) and Bower installed globally.
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -75,7 +75,7 @@ Vagrant.configure("2") do |config|
     sudo apt-get update
     sudo apt-get upgrade
     sudo apt-get install git -y
-    curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
+    curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
     sudo apt-get install -y nodejs
     sudo npm install npm -g
     sudo npm install gulp-cli -g


### PR DESCRIPTION
Support for Node 6.x LTS has ended in April 2019. This bumps the version to 10.x to maintain support until April 2021.